### PR TITLE
use gradle build in newer archiver-appliance versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ Configuration Environment for [Customized or Legacy EPICS Archiver Appliance](ht
 
 
 ## Debian 12
+will use a manually downloaded version of tomcat9, installed to /opt/tomcat9
 
 ### Pre-requirement packages
 
@@ -33,6 +34,7 @@ make sql.show
 make vars FILTER=TOMCAT
 make tomcat.get
 make tomcat.install
+make tomcat.installmdb # will install mariadb jdbc connector to tomcat's libs
 make tomcat.exist
 ```
 

--- a/configure/CONFIG_TOMCAT
+++ b/configure/CONFIG_TOMCAT
@@ -1,12 +1,17 @@
 #
 #
 TOMCAT_MAJOR_VER:=9
-TOMCAT_MINOR_VER:=0.87
+TOMCAT_MINOR_VER:=0.93
 TOMCAT_INSTALL_LOCATION:=${AA_INSTALL_PATH}/tomcat$(TOMCAT_MAJOR_VER)
 TOMCAT_VER:=$(TOMCAT_MAJOR_VER).$(TOMCAT_MINOR_VER)
 TOMCAT_SRC:=apache-tomcat-$(TOMCAT_VER).tar.gz
 #
 TOMCAT_URL:="https://archive.apache.org/dist/tomcat/tomcat-$(TOMCAT_MAJOR_VER)/v$(TOMCAT_VER)/bin/$(TOMCAT_SRC)"
+#
+MARIADB_JDBC_VERSION:="3.4.1"
+MARIADB_JDBC_FILE:="mariadb-java-client-$(MARIADB_JDBC_VERSION).jar"
+# the number 3852266 might change with newer versions of mariadb ?!
+MARIADB_URL:="https://dlm.mariadb.com/3852266/Connectors/java/connector-java-$(MARIADB_JDBC_VERSION)/$(MARIADB_JDBC_FILE)"
 #
 TOMCAT_DEFAULT_PORT:=8083
 TOMCAT_DEFAULT_SERVER_XML:=server.xml

--- a/configure/RULES_SRC
+++ b/configure/RULES_SRC
@@ -78,7 +78,7 @@ build.gradle: copy.sitespecific | mkdir.wars
 	export ARCHAPPL_SITEID=$(ARCHAPPL_SITEID) && \
 	cd $(SRC_PATH) && JAVA_HOME=$(JAVA_HOME) && \
 	./gradlew && \
-	cp build/libs/*war ../wars/ && \
+	cp build/libs/*war $(ARCHAPPL_WARS_TARGET_PATH)/ && \
 	cd ..
 
 copy.sitespecific: | FORCE

--- a/configure/RULES_SRC
+++ b/configure/RULES_SRC
@@ -46,7 +46,7 @@ deinit: distclean
 distclean:
 	$(call distclean, $(SRC_PATH))
 
-.PHONY: info.ant clean.ant  build.ant copy.sitespecific mkdir.wars
+.PHONY: info.ant clean.gradle clean.ant  build.ant copy.sitespecific mkdir.wars
 
 ## Ant and Java
 info.ant:
@@ -64,13 +64,21 @@ info.ant:
 clean.ant: info.ant
 	cd $(SRC_PATH) && JAVA_HOME=$(JAVA_HOME) $(ANT_CMD) $(ANT_OPTS) clean && cd ..
 
+clean.gradle:
+	cd $(SRC_PATH) && JAVA_HOME=$(JAVA_HOME) ./gradlew clean && cd ..
+
 ## Build
 build.ant: info.ant copy.sitespecific | mkdir.wars
 	cd $(SRC_PATH) && JAVA_HOME=$(JAVA_HOME) $(ANT_CMD) $(ANT_OPTS) && cd ..
 
 # Gradle experiment
 build.gradle: copy.sitespecific | mkdir.wars
-	cd $(SRC_PATH) && JAVA_HOME=$(JAVA_HOME) ./gradlew war && cp build/libs/*.war ../wars/ && cd ..
+	cd $(SRC_PATH) && JAVA_HOME=$(JAVA_HOME) && \
+	./gradlew && \
+	cd build/distributions && \
+	tar --wildcards -xvzf archappl*tar.gz *.war && \
+	cp *.war ../../../wars/ && \
+	cd ../../
 
 copy.sitespecific: | FORCE
 	$(QUIET)echo "-------------------------------------------------------------"
@@ -87,7 +95,7 @@ mkdir.wars:
 
 
 ## Conf and Build
-build: conf build.ant
+build: conf build.gradle
 
 ## Configuration
 conf: conf.archapplproperties conf.storage

--- a/configure/RULES_SRC
+++ b/configure/RULES_SRC
@@ -68,9 +68,9 @@ clean.ant: info.ant
 build.ant: info.ant copy.sitespecific | mkdir.wars
 	cd $(SRC_PATH) && JAVA_HOME=$(JAVA_HOME) $(ANT_CMD) $(ANT_OPTS) && cd ..
 
-## Site Build
-build.site: info.ant copy.sitespecific | mkdir.wars
-	cd $(SRC_PATH) && JAVA_HOME=$(JAVA_HOME) $(ANT_CMD) $(ANT_OPTS) sitespecificbuild && cd ..
+# Gradle experiment
+build.gradle: copy.sitespecific | mkdir.wars
+	cd $(SRC_PATH) && JAVA_HOME=$(JAVA_HOME) ./gradlew war && cp build/libs/*.war ../wars/ && cd ..
 
 copy.sitespecific: | FORCE
 	$(QUIET)echo "-------------------------------------------------------------"

--- a/configure/RULES_SRC
+++ b/configure/RULES_SRC
@@ -71,14 +71,15 @@ clean.gradle:
 build.ant: info.ant copy.sitespecific | mkdir.wars
 	cd $(SRC_PATH) && JAVA_HOME=$(JAVA_HOME) $(ANT_CMD) $(ANT_OPTS) && cd ..
 
-# Gradle experiment
+## Build with Gradle
+##	tar --wildcards -xvzf build/distributions/archappl*tar.gz *.war -C ../../../../wars/ && \
+
 build.gradle: copy.sitespecific | mkdir.wars
+	export ARCHAPPL_SITEID=$(ARCHAPPL_SITEID) && \
 	cd $(SRC_PATH) && JAVA_HOME=$(JAVA_HOME) && \
 	./gradlew && \
-	cd build/distributions && \
-	tar --wildcards -xvzf archappl*tar.gz *.war && \
-	cp *.war ../../../wars/ && \
-	cd ../../
+	cp build/libs/*war ../wars/ && \
+	cd ..
 
 copy.sitespecific: | FORCE
 	$(QUIET)echo "-------------------------------------------------------------"

--- a/configure/RULES_TOMCAT
+++ b/configure/RULES_TOMCAT
@@ -43,6 +43,11 @@ tomcat.install: tomcat.preinst tomcat.src_install tomcat.update
 	$(QUIET)$(SUDO) chmod 644 $(TOMCAT_INSTALL_LOCATION)/bin/*.jar
 #	$(QUIET)$(SUDO) chmod 755 $(TOMCAT_INSTALL_LOCATION)/bin/*.sh
 
+tomcat.installmdb: tomcat.preinst
+	$(QUIET)$(SUDO) rm -rf $(TOMCAT_INSTALL_LOCATION)/lib/$(MARIADB_JDBC_FILE)
+	$(QUIET)$(SUDO) wget $(MARIADB_URL) -P $(TOMCAT_INSTALL_LOCATION)/lib/
+	$(SUDO) chown $(AA_USERID):$(AA_GROUPID) $(TOMCAT_INSTALL_LOCATION)/lib/$(MARIADB_JDBC_FILE)
+
 tomcat.installall: tomcat.preinst tomcat.src_install tomcat.update tomcat.sd_install tomcat.sd_enable
 	$(QUIET)$(SUDO) chown -R $(AA_USERID):$(AA_GROUPID) $(TOMCAT_INSTALL_LOCATION)
 	$(QUIET)$(SUDO) chmod -R 755 $(TOMCAT_INSTALL_LOCATION)/lib

--- a/scripts/required_pkgs.sh
+++ b/scripts/required_pkgs.sh
@@ -160,7 +160,7 @@ function debian12_pkgs
                    mariadb-client  \
                    libmariadb-dev \
                    libmariadb-dev-compat \
-                   openjdk-17-jdk \
+                   openjdk-17-jdk-headless \
                    ant \
     
 }

--- a/scripts/required_pkgs.sh
+++ b/scripts/required_pkgs.sh
@@ -162,22 +162,7 @@ function debian12_pkgs
                    libmariadb-dev-compat \
                    openjdk-17-jdk \
                    ant \
-                   tomcat10 \
-                   tomcat10-common \
-                   tomcat10-admin \
-                   tomcat10-user \
-                   libtomcat10-java \
-                   jsvc \
-                   chrony 
     
-    ln -sf "$(which mariadb_config)" /usr/bin/mysql_config
-    # MySQL-python-1.2.5 doesn't work with mariadb 
-    # https://lists.launchpad.net/maria-developers/msg10744.html
-    # https://github.com/DefectDojo/django-DefectDojo/issues/407
-
-    if [ ! -f /usr/include/mariadb/mysql.h.bkp ]; then
-        sed '/st_mysql_options options;/a unsigned int reconnect;' /usr/include/mariadb/mysql.h -i.bkp
-    fi
 }
 
 function centos7_pkgs

--- a/scripts/required_pkgs.sh
+++ b/scripts/required_pkgs.sh
@@ -139,6 +139,47 @@ function debian11_pkgs
     fi
 }
 
+function debian12_pkgs
+{
+    ## Debian 12
+    apt update -y
+    apt install -y wget \
+                   curl \
+    	           git \
+    	           sed \
+                   gawk \
+                   unzip \
+                   make \
+                   gcc \
+                   tree \
+                   python3 \
+                   python3-pip \
+                   python-is-python3 \
+                   python3-venv \
+    	           mariadb-server \
+                   mariadb-client  \
+                   libmariadb-dev \
+                   libmariadb-dev-compat \
+                   openjdk-17-jdk \
+                   ant \
+                   tomcat10 \
+                   tomcat10-common \
+                   tomcat10-admin \
+                   tomcat10-user \
+                   libtomcat10-java \
+                   jsvc \
+                   chrony 
+    
+    ln -sf "$(which mariadb_config)" /usr/bin/mysql_config
+    # MySQL-python-1.2.5 doesn't work with mariadb 
+    # https://lists.launchpad.net/maria-developers/msg10744.html
+    # https://github.com/DefectDojo/django-DefectDojo/issues/407
+
+    if [ ! -f /usr/include/mariadb/mysql.h.bkp ]; then
+        sed '/st_mysql_options options;/a unsigned int reconnect;' /usr/include/mariadb/mysql.h -i.bkp
+    fi
+}
+
 function centos7_pkgs
 {
     yum update -y;
@@ -223,6 +264,7 @@ echo "$dist"
 case "$dist" in
     *buster*)   debian10_pkgs ;;
     *bullseye*) debian11_pkgs ;;
+    *bookworm*) debian12_pkgs ;;
     *CentOS* | *Scientific* ) 
         centos_version=$(centos_dist)
         if [ "$centos_version" == "7" ]; then


### PR DESCRIPTION
Hi,

I was using your aa-env for some time and was very pleased with the simplicity.
unfortunately, it didnt work with the newest community archiver-appliance, mainly because they switched to gradle.
(I use a custom RELEASE.local to use the other repo)

this is my attempt to use gradle for the AA, and leave everything as-is.

also, I noticed that the setup script `required_pkgs.sh` didnt like my debian 12.

I made some changes here to install on debian 12:
- create a new function for debian 12
- dont install tomcat from debian repos as they only provide tomcat10 now
- use openjdk-17-jdk-headless to prevent a server from installing GUI components like X11 stuff ...
- install python3 stuff for the new gradle build, that uses sphinx to create the docs

additionally, I now use the existing function to download tomcat9 to /opt/
and added a function to put the mariadb-jdbc-connector in its lib directory. (`make tomcat.installmdb`)

runs happily on debian 12 :)

hth,
William